### PR TITLE
Enable collaborative encrypted notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+notes.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Collaborative E2E Encrypted Note App
+
+This web app lets multiple devices share notes through a lightweight Node server.
+Notes are encrypted in the browser with a shared passphrase so the server cannot
+read them.
+
+## Setup
+
+1. Run `node server.js` to start the server on port 3000.
+2. Open `http://localhost:3000` in each browser or device.
+3. When prompted, enter the same passphrase on every device to decrypt shared notes.
+
+## Usage
+
+Type a note and click **Add Note**. The note is encrypted and sent to the server
+so it appears on other devices using the same passphrase. Use the Delete button
+to remove a note from the shared store.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Collaborative Notes</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Collaborative Notes</h1>
+  <p>Enter a shared passphrase when prompted to encrypt notes end-to-end.</p>
+  <form id="note-form">
+    <textarea id="note-input" placeholder="Write a note..."></textarea>
+    <button type="submit">Add Note</button>
+  </form>
+  <ul id="notes-list"></ul>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "note-app",
+  "version": "1.1.0",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests\" && exit 0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,76 @@
+const form = document.getElementById('note-form');
+const input = document.getElementById('note-input');
+const list = document.getElementById('notes-list');
+let key;
+
+async function deriveKey(passphrase) {
+  const enc = new TextEncoder();
+  const salt = enc.encode('shared-salt');
+  const baseKey = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+function bufToB64(buf) {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+function b64ToBuf(b64) {
+  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+}
+
+async function encrypt(text) {
+  const enc = new TextEncoder();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(text));
+  return { cipher: bufToB64(cipher), iv: Array.from(iv) };
+}
+
+async function decrypt(cipher, iv) {
+  const dec = new TextDecoder();
+  const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv: new Uint8Array(iv) }, key, b64ToBuf(cipher));
+  return dec.decode(plain);
+}
+
+async function loadNotes() {
+  const res = await fetch('/notes');
+  const encryptedNotes = await res.json();
+  list.innerHTML = '';
+  for (const [index, { cipher, iv }] of encryptedNotes.entries()) {
+    const text = await decrypt(cipher, iv);
+    const li = document.createElement('li');
+    li.textContent = text;
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.addEventListener('click', async () => {
+      await fetch('/notes/' + index, { method: 'DELETE' });
+      loadNotes();
+    });
+    li.appendChild(del);
+    list.appendChild(li);
+  }
+}
+
+form.addEventListener('submit', async e => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text) return;
+  const encrypted = await encrypt(text);
+  await fetch('/notes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(encrypted)
+  });
+  input.value = '';
+  loadNotes();
+});
+
+window.addEventListener('DOMContentLoaded', async () => {
+  const pass = prompt('Enter shared passphrase');
+  key = await deriveKey(pass);
+  loadNotes();
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,77 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const DATA_FILE = path.join(__dirname, 'notes.json');
+let notes = [];
+try {
+  notes = JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+} catch (err) {
+  notes = [];
+}
+function saveNotes() {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(notes));
+}
+function serveStatic(req, res) {
+  const filePath = path.join(
+    __dirname,
+    req.url === '/' ? 'index.html' : req.url
+  );
+  const ext = path.extname(filePath).toLowerCase();
+  const types = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json'
+  };
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': types[ext] || 'text/plain' });
+    res.end(content);
+  });
+}
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/notes') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(notes));
+  } else if (req.method === 'POST' && req.url === '/notes') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { cipher, iv } = JSON.parse(body);
+        if (!cipher || !iv) {
+          res.writeHead(400);
+          res.end('Invalid');
+          return;
+        }
+        notes.push({ cipher, iv });
+        saveNotes();
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end('{"ok":true}');
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else if (req.method === 'DELETE' && req.url.startsWith('/notes/')) {
+    const index = parseInt(req.url.split('/')[2], 10);
+    if (Number.isNaN(index) || index < 0 || index >= notes.length) {
+      res.writeHead(400);
+      res.end('Invalid index');
+      return;
+    }
+    notes.splice(index, 1);
+    saveNotes();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{"ok":true}');
+  } else {
+    serveStatic(req, res);
+  }
+});
+const port = process.env.PORT || 3000;
+server.listen(port, () => console.log(`Server running on ${port}`));

--- a/style.css
+++ b/style.css
@@ -1,0 +1,5 @@
+body { font-family: sans-serif; margin: 2rem; }
+#note-form { margin-bottom: 1rem; }
+#note-input { width: 100%; height: 4rem; }
+#notes-list li { margin-bottom: .5rem; }
+#notes-list button { margin-left: 1rem; }


### PR DESCRIPTION
## Summary
- Add Node-based server to store encrypted notes and serve static files
- Encrypt notes with shared passphrase using Web Crypto API for end-to-end security
- Document setup for running collaborative note sharing across devices

## Testing
- `node --check script.js`
- `node --check server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689cdb4ffe248324a89c1e321c2d0ec1