### PR TITLE
Handle anonymous auth after DOM load

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,7 +23,6 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
-await signInAnonymously(auth); // gives a uid for security rules
 
 // --- DOM + crypto helpers
 let form, input, list;
@@ -106,6 +105,12 @@ window.addEventListener('DOMContentLoaded', async () => {
   input = document.getElementById('note-input');
   list = document.getElementById('notes-list');
   bindForm();
+  try {
+    await signInAnonymously(auth); // gives a uid for security rules
+  } catch (err) {
+    console.error('Failed to sign in anonymously', err);
+    return;
+  }
 
   const pass = prompt('Enter shared passphrase');
   if (!pass) return;


### PR DESCRIPTION
## Summary
- Move anonymous sign-in into `DOMContentLoaded` handler
- Derive encryption key and start realtime notes after signing in
- Log and abort on anonymous sign-in failures

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e1b4e4408832496fc8791a8f17530