### PR TITLE
feat: allow editing notes

### DIFF
--- a/script.js
+++ b/script.js
@@ -4,7 +4,7 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-app.js';
 import {
   getFirestore, collection, addDoc, onSnapshot,
-  deleteDoc, doc, query, orderBy, serverTimestamp
+  deleteDoc, updateDoc, doc, query, orderBy, serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-firestore.js';
 import { getAuth, signInAnonymously } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-auth.js';
 
@@ -23,11 +23,10 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
 const auth = getAuth(app);
-await signInAnonymously(auth); // gives a uid for security rules
 
 // --- DOM + crypto helpers
 let form, input, list;
-let key;
+let key, username;
 
 async function deriveKey(passphrase) {
   const enc = new TextEncoder();
@@ -71,16 +70,31 @@ function startRealtimeNotes() {
   onSnapshot(q, async (snap) => {
     list.innerHTML = '';
     for (const docSnap of snap.docs) {
-      const { cipher, iv } = docSnap.data();
+      const { cipher, iv, username: noteUser } = docSnap.data();
       try {
         const text = await decrypt(cipher, iv);
         const li = document.createElement('li');
-        li.textContent = text;
+        li.textContent = noteUser ? `${noteUser}: ${text}` : text;
+        const edit = document.createElement('button');
+        edit.textContent = 'Edit';
+        edit.addEventListener('click', async () => {
+          try {
+            const newText = prompt('Edit note', text);
+            if (newText === null) return;
+            const trimmed = newText.trim();
+            if (!trimmed) return;
+            const { cipher: newCipher, iv: newIv } = await encrypt(trimmed);
+            await updateDoc(doc(db, 'notes', docSnap.id), { cipher: newCipher, iv: newIv });
+          } catch (err) {
+            console.error('Failed to edit note', err);
+          }
+        });
         const del = document.createElement('button');
         del.textContent = 'Delete';
         del.addEventListener('click', async () => {
           await deleteDoc(doc(db, 'notes', docSnap.id));
         });
+        li.appendChild(edit);
         li.appendChild(del);
         list.appendChild(li);
       } catch (err) {
@@ -96,7 +110,7 @@ function bindForm() {
     const text = input.value.trim();
     if (!text) return;
     const encrypted = await encrypt(text);
-    await addDoc(collection(db, 'notes'), encrypted);
+    await addDoc(collection(db, 'notes'), { ...encrypted, username });
     input.value = '';
   });
 }
@@ -106,6 +120,15 @@ window.addEventListener('DOMContentLoaded', async () => {
   input = document.getElementById('note-input');
   list = document.getElementById('notes-list');
   bindForm();
+  try {
+    await signInAnonymously(auth); // gives a uid for security rules
+  } catch (err) {
+    console.error('Failed to sign in anonymously', err);
+    return;
+  }
+
+  username = (prompt('Enter username') || '').trim();
+  if (!username) return;
 
   const pass = prompt('Enter shared passphrase');
   if (!pass) return;


### PR DESCRIPTION
## Summary
- allow editing of existing notes with updateDoc and encryption
- prompt for a username on sign-in and store it with newly added notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e1b4e4408832496fc8791a8f17530