### PR TITLE
Add cases with tasks and notes subcollections

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,14 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /notes/{noteId} {
+    match /cases/{caseId} {
       allow read, write: if request.auth != null;
+      match /tasks/{taskId} {
+        allow read, write: if request.auth != null;
+      }
+      match /notes/{noteId} {
+        allow read, write: if request.auth != null;
+      }
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -14,9 +14,18 @@
     <button type="submit">Add Note</button>
   </form>
   <ul id="notes-list"></ul>
-  <script type="module" src="script.js"></script>
+
+  <h2>Tasks</h2>
+  <form id="task-form">
+    <input id="task-input" placeholder="New task" />
+    <select id="task-status">
+      <option value="open" selected>Open</option>
+      <option value="done">Done</option>
+    </select>
+    <button type="submit">Add Task</button>
+  </form>
+  <ul id="tasks-list"></ul>
 
   <script type="module" src="script.js"></script>
-
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Introduce `cases` collection with nested `tasks` and `notes`
- Add task UI and logic for encrypted tasks with status
- Update Firestore rules for new collection structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f60abae388324addb378233c84455