### PR TITLE
Share crypto utilities and encrypt Firestore writes

### DIFF
--- a/crypto.js
+++ b/crypto.js
@@ -1,0 +1,46 @@
+import { serverTimestamp } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-firestore.js';
+
+let key;
+
+export function setKey(derivedKey) {
+  key = derivedKey;
+}
+
+export async function deriveKey(passphrase) {
+  const enc = new TextEncoder();
+  const salt = enc.encode('shared-salt'); // TODO: production: use a random per-space salt
+  const baseKey = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
+    baseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt']
+  );
+}
+
+function bufToB64(buf) {
+  return btoa(String.fromCharCode(...new Uint8Array(buf)));
+}
+
+function b64ToBuf(b64) {
+  return Uint8Array.from(atob(b64), c => c.charCodeAt(0));
+}
+
+export async function encrypt(text) {
+  const enc = new TextEncoder();
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(text));
+  return { cipher: bufToB64(cipher), iv: Array.from(iv), createdAt: serverTimestamp() };
+}
+
+export async function decrypt(cipher, iv) {
+  const dec = new TextDecoder();
+  const plain = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: new Uint8Array(iv) },
+    key,
+    b64ToBuf(cipher)
+  );
+  return dec.decode(plain);
+}
+

--- a/script.js
+++ b/script.js
@@ -4,9 +4,10 @@
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-app.js';
 import {
   getFirestore, collection, addDoc, onSnapshot,
-  deleteDoc, updateDoc, doc, query, orderBy, serverTimestamp
+  deleteDoc, updateDoc, doc, query, orderBy
 } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-firestore.js';
 import { getAuth, signInAnonymously } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-auth.js';
+import { deriveKey, setKey, encrypt, decrypt } from './crypto.js';
 
 // --- Your Firebase config (safe to commit; rules protect data)
 const firebaseConfig = {
@@ -26,41 +27,7 @@ const auth = getAuth(app);
 
 // --- DOM + crypto helpers
 let form, input, list;
-let key, username;
-
-async function deriveKey(passphrase) {
-  const enc = new TextEncoder();
-  const salt = enc.encode('shared-salt'); // TODO: production: use a random per-space salt
-
-  const baseKey = await crypto.subtle.importKey('raw', enc.encode(passphrase), 'PBKDF2', false, ['deriveKey']);
-  return crypto.subtle.deriveKey(
-    { name: 'PBKDF2', salt, iterations: 100000, hash: 'SHA-256' },
-    baseKey,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt']
-  );
-}
-
-function bufToB64(buf) { return btoa(String.fromCharCode(...new Uint8Array(buf))); }
-function b64ToBuf(b64) { return Uint8Array.from(atob(b64), c => c.charCodeAt(0)); }
-
-async function encrypt(text) {
-  const enc = new TextEncoder();
-  const iv = crypto.getRandomValues(new Uint8Array(12));
-  const cipher = await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, enc.encode(text));
-  return { cipher: bufToB64(cipher), iv: Array.from(iv), createdAt: serverTimestamp() };
-}
-
-async function decrypt(cipher, iv) {
-  const dec = new TextDecoder();
-  const plain = await crypto.subtle.decrypt(
-    { name: 'AES-GCM', iv: new Uint8Array(iv) },
-    key,
-    b64ToBuf(cipher) // Uint8Array is fine here
-  );
-  return dec.decode(plain);
-}
+let username;
 
 // --- Firestore-backed UI
 function startRealtimeNotes() {
@@ -133,7 +100,8 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   const pass = prompt('Enter shared passphrase');
   if (!pass) return;
-  key = await deriveKey(pass);
+  const derived = await deriveKey(pass);
+  setKey(derived);
 
   startRealtimeNotes();
 });


### PR DESCRIPTION
## Summary
- expose shared encryption helpers in new `crypto.js`
- update note logic to use shared encrypt/decrypt utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f62a81ed48324a7b1125d75a251ea