### PR TITLE
Add cases list and detail view

### DIFF
--- a/cases.js
+++ b/cases.js
@@ -1,0 +1,92 @@
+// cases.js - manage cases with tasks and notes
+import { initializeApp } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-app.js';
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp
+} from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-firestore.js';
+import { getAuth, signInAnonymously } from 'https://www.gstatic.com/firebasejs/11.0.0/firebase-auth.js';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyBo5a6Uxk1vJwS8WqFnccjSnNOOXreOhcg",
+  authDomain: "catalist-1.firebaseapp.com",
+  projectId: "catalist-1",
+  storageBucket: "catalist-1.firebasestorage.app",
+  messagingSenderId: "843924921323",
+  appId: "1:843924921323:web:0e7a847f8cd70db55f57ae",
+  measurementId: "G-6NZEC4ED4C"
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+const auth = getAuth(app);
+
+let caseForm, caseInput, casesList, detail, detailTitle, tasksList, notesList;
+
+function showCase(id, title) {
+  detailTitle.textContent = title;
+  detail.style.display = 'block';
+
+  const tasksQ = query(collection(db, 'cases', id, 'tasks'), orderBy('createdAt', 'desc'));
+  onSnapshot(tasksQ, snap => {
+    tasksList.innerHTML = '';
+    snap.forEach(docSnap => {
+      const li = document.createElement('li');
+      li.textContent = docSnap.data().text || '';
+      tasksList.appendChild(li);
+    });
+  });
+
+  const notesQ = query(collection(db, 'cases', id, 'notes'), orderBy('createdAt', 'desc'));
+  onSnapshot(notesQ, snap => {
+    notesList.innerHTML = '';
+    snap.forEach(docSnap => {
+      const li = document.createElement('li');
+      li.textContent = docSnap.data().text || '';
+      notesList.appendChild(li);
+    });
+  });
+}
+
+async function init() {
+  caseForm = document.getElementById('case-form');
+  caseInput = document.getElementById('case-input');
+  casesList = document.getElementById('cases-list');
+  detail = document.getElementById('case-detail');
+  detailTitle = document.getElementById('case-title');
+  tasksList = document.getElementById('tasks-list');
+  notesList = document.getElementById('case-notes-list');
+
+  try {
+    await signInAnonymously(auth);
+  } catch (err) {
+    console.error('Failed to sign in anonymously', err);
+    return;
+  }
+
+  caseForm.addEventListener('submit', async e => {
+    e.preventDefault();
+    const title = caseInput.value.trim();
+    if (!title) return;
+    await addDoc(collection(db, 'cases'), { title, createdAt: serverTimestamp() });
+    caseInput.value = '';
+  });
+
+  const casesQ = query(collection(db, 'cases'), orderBy('createdAt', 'desc'));
+  onSnapshot(casesQ, snap => {
+    casesList.innerHTML = '';
+    snap.forEach(docSnap => {
+      const { title } = docSnap.data();
+      const li = document.createElement('li');
+      li.textContent = title;
+      li.addEventListener('click', () => showCase(docSnap.id, title));
+      casesList.appendChild(li);
+    });
+  });
+}
+
+window.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -2,21 +2,27 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Collaborative Notes</title>
+  <title>Case Manager</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Collaborative Notes</h1>
-  <p>Enter a shared passphrase when prompted to encrypt notes end-to-end.</p>
+  <h1>Cases</h1>
 
-  <form id="note-form">
-    <textarea id="note-input" placeholder="Write a note..."></textarea>
-    <button type="submit">Add Note</button>
+  <form id="case-form">
+    <input id="case-input" placeholder="New case title" />
+    <button type="submit">Add Case</button>
   </form>
-  <ul id="notes-list"></ul>
-  <script type="module" src="script.js"></script>
+  <ul id="cases-list"></ul>
 
-  <script type="module" src="script.js"></script>
+  <div id="case-detail" style="display:none;">
+    <h2 id="case-title"></h2>
+    <h3>Tasks</h3>
+    <ul id="tasks-list"></ul>
+    <h3>Notes</h3>
+    <ul id="case-notes-list"></ul>
+  </div>
+
+  <script type="module" src="cases.js"></script>
 
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
 body { font-family: sans-serif; margin: 2rem; }
-#note-form { margin-bottom: 1rem; }
-#note-input { width: 100%; height: 4rem; }
-#notes-list li { margin-bottom: .5rem; }
-#notes-list button { margin-left: 1rem; }
+#case-form { margin-bottom: 1rem; }
+#case-input { width: 100%; }
+#cases-list li { margin-bottom: .5rem; cursor: pointer; }
+#cases-list li:hover { text-decoration: underline; }
+#case-detail { margin-top: 2rem; }


### PR DESCRIPTION
## Summary
- Query Firestore `cases` ordered by creation time and show them in a clickable list
- Add a form to create new cases and insert them into Firestore
- Display tasks and notes for a selected case in a detail view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f63aee0c883249970230ee46d0ad9