### PR TITLE
Abort case list loading on key derivation failure

### DIFF
--- a/script.js
+++ b/script.js
@@ -133,7 +133,12 @@ window.addEventListener('DOMContentLoaded', async () => {
 
   const pass = prompt('Enter shared passphrase');
   if (!pass) return;
-  key = await deriveKey(pass);
+  try {
+    key = await deriveKey(pass);
+  } catch (err) {
+    console.error('Failed to derive key', err);
+    return;
+  }
 
   startRealtimeNotes();
 });


### PR DESCRIPTION
## Summary
- guard key derivation inside DOMContentLoaded
- abort loading notes if key derivation fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f688b46dc8324b8ef03bb29ed70fe