### PR TITLE
Add E2EE case-based tasks and notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
+# Collaborative E2E Encrypted Case Tracker
 
-# Collaborative E2E Encrypted Note App
-
-This web app stores notes in Firebase Firestore. Notes are encrypted in the browser with a shared passphrase, so the database only sees ciphertext.
+This web app demonstrates a simple case list for medical professionals. Each case contains its own task list and free-text notes. All case titles, tasks, comments and notes are encrypted in the browser with a shared passphrase, so Firestore only stores ciphertext.
 
 ## Setup
 
@@ -12,5 +11,4 @@ This web app stores notes in Firebase Firestore. Notes are encrypted in the brow
 
 ## Usage
 
-When prompted, enter the same passphrase on every device. Each note you add is encrypted with AES-GCM and written to the `notes` collection in Firestore. Devices using the same passphrase decrypt and display the shared notes. Notes created with different passphrases remain unreadable and are ignored.
-
+When prompted, enter a username and the shared passphrase on every device. Cases, tasks and notes you add are encrypted with AES-GCM and written to the `cases` collection in Firestore. Devices using the same passphrase decrypt and display the shared data. Information created with different passphrases remains unreadable and is ignored.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,17 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /notes/{noteId} {
+    match /cases/{caseId} {
       allow read, write: if request.auth != null;
+      match /notes/{noteId} {
+        allow read, write: if request.auth != null;
+      }
+      match /tasks/{taskId} {
+        allow read, write: if request.auth != null;
+        match /comments/{commentId} {
+          allow read, write: if request.auth != null;
+        }
+      }
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -2,21 +2,47 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Collaborative Notes</title>
+  <title>Case Tasks & Notes</title>
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Collaborative Notes</h1>
-  <p>Enter a shared passphrase when prompted to encrypt notes end-to-end.</p>
+  <div id="case-list-section">
+    <h1>Cases</h1>
+    <ul id="case-list"></ul>
+    <form id="case-form">
+      <input id="case-input" placeholder="New case title">
+      <button type="submit">Add Case</button>
+    </form>
+  </div>
 
-  <form id="note-form">
-    <textarea id="note-input" placeholder="Write a note..."></textarea>
-    <button type="submit">Add Note</button>
-  </form>
-  <ul id="notes-list"></ul>
+  <div id="case-detail" hidden>
+    <button id="back-btn">Back</button>
+    <h2 id="case-title"></h2>
+
+    <section id="tasks">
+      <h3>Tasks</h3>
+      <form id="task-form">
+        <input id="task-input" placeholder="Task description">
+        <select id="task-status">
+          <option value="open">Open</option>
+          <option value="in progress">In Progress</option>
+          <option value="complete">Complete</option>
+        </select>
+        <button type="submit">Add Task</button>
+      </form>
+      <ul id="task-list"></ul>
+    </section>
+
+    <section id="notes">
+      <h3>Notes</h3>
+      <form id="note-form">
+        <textarea id="note-input" placeholder="Add note..."></textarea>
+        <button type="submit">Add Note</button>
+      </form>
+      <ul id="notes-list"></ul>
+    </section>
+  </div>
+
   <script type="module" src="script.js"></script>
-
-  <script type="module" src="script.js"></script>
-
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,5 +1,8 @@
 body { font-family: sans-serif; margin: 2rem; }
-#note-form { margin-bottom: 1rem; }
-#note-input { width: 100%; height: 4rem; }
-#notes-list li { margin-bottom: .5rem; }
-#notes-list button { margin-left: 1rem; }
+form { margin: 1rem 0; }
+textarea { width: 100%; height: 4rem; }
+#case-list li { cursor: pointer; margin-bottom: .5rem; }
+#task-list li { margin-bottom: .5rem; }
+#task-list select { margin-left: .5rem; }
+#task-list button { margin-left: .5rem; }
+.comments { margin-left: 1.5rem; font-size: 0.9em; }


### PR DESCRIPTION
## Summary
- Add case list UI with per-case tasks and notes pages
- Encrypt case titles, tasks, comments, and notes end-to-end
- Expand Firestore rules for cases, tasks, notes, and comments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f7b795a348324a8cf2a83c98748de