### PR TITLE
Revamp UI with modern mobile-first design

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,47 +2,53 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Case Tasks & Notes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="case-list-section">
-    <h1>Cases</h1>
-    <ul id="case-list"></ul>
-    <form id="case-form">
-      <input id="case-input" placeholder="New case title">
-      <button type="submit">Add Case</button>
-    </form>
-  </div>
-
-  <div id="case-detail" hidden>
-    <button id="back-btn">Back</button>
-    <h2 id="case-title"></h2>
-
-    <section id="tasks">
-      <h3>Tasks</h3>
-      <form id="task-form">
-        <input id="task-input" placeholder="Task description">
-        <select id="task-status">
-          <option value="open">Open</option>
-          <option value="in progress">In Progress</option>
-          <option value="complete">Complete</option>
-        </select>
-        <button type="submit">Add Task</button>
+  <main class="app">
+    <section id="case-list-section" class="card">
+      <h1>Cases</h1>
+      <ul id="case-list"></ul>
+      <form id="case-form" class="stack">
+        <input id="case-input" placeholder="New case title">
+        <button type="submit" class="primary">Add Case</button>
       </form>
-      <ul id="task-list"></ul>
     </section>
 
-    <section id="notes">
-      <h3>Notes</h3>
-      <form id="note-form">
-        <textarea id="note-input" placeholder="Add note..."></textarea>
-        <button type="submit">Add Note</button>
-      </form>
-      <ul id="notes-list"></ul>
-    </section>
-  </div>
+    <section id="case-detail" class="card" hidden>
+      <button id="back-btn" class="back-btn">&larr; Back</button>
+      <h2 id="case-title"></h2>
 
+      <section id="tasks">
+        <h3>Tasks</h3>
+        <form id="task-form" class="stack">
+          <input id="task-input" placeholder="Task description">
+          <select id="task-status" class="status-select" data-status="open">
+            <option value="open">Open</option>
+            <option value="in progress">In Progress</option>
+            <option value="complete">Complete</option>
+          </select>
+          <button type="submit" class="primary">Add Task</button>
+        </form>
+        <ul id="task-list"></ul>
+      </section>
+
+      <section id="notes">
+        <h3>Notes</h3>
+        <form id="note-form" class="stack">
+          <textarea id="note-input" placeholder="Add note..."></textarea>
+          <button type="submit" class="primary">Add Note</button>
+        </form>
+        <ul id="notes-list"></ul>
+      </section>
+    </section>
+  </main>
   <script type="module" src="script.js"></script>
 </body>
 </html>
+

--- a/style.css
+++ b/style.css
@@ -1,8 +1,228 @@
-body { font-family: sans-serif; margin: 2rem; }
-form { margin: 1rem 0; }
-textarea { width: 100%; height: 4rem; }
-#case-list li { cursor: pointer; margin-bottom: .5rem; }
-#task-list li { margin-bottom: .5rem; }
-#task-list select { margin-left: .5rem; }
-#task-list button { margin-left: .5rem; }
-.comments { margin-left: 1.5rem; font-size: 0.9em; }
+:root {
+  --bg: #f5f7fa;
+  --card-bg: #ffffff;
+  --primary: #2563eb;
+  --primary-hover: #1e40af;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --radius: 0.5rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.app {
+  padding: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  margin: 0 0 1rem;
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stack > * + * {
+  margin-top: 0.75rem;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+  background: #fff;
+}
+
+textarea {
+  min-height: 4rem;
+  resize: vertical;
+}
+
+button {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+button.primary:hover {
+  background: var(--primary-hover);
+}
+
+.back-btn {
+  background: none;
+  color: var(--muted);
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+#case-list li,
+#task-list li,
+#notes-list li {
+  padding: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius);
+  margin-bottom: 0.5rem;
+  background: #fff;
+}
+
+#case-list li {
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#case-list li:hover {
+  background: #f3f4f6;
+}
+
+#task-form,
+#note-form {
+  margin-top: 1rem;
+}
+
+#task-form select {
+  margin-top: 0.75rem;
+}
+
+#notes-list li button {
+  margin-left: 0.5rem;
+  background: none;
+  color: var(--primary);
+}
+
+#task-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.task-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task-header span {
+  flex: 1;
+}
+
+.status-select {
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.status-select[data-status="open"] {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-select[data-status="in progress"] {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-select[data-status="complete"] {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.task-item[data-status="complete"] span {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+
+.comment-toggle {
+  background: none;
+  color: var(--primary);
+  padding: 0.25rem 0.5rem;
+}
+
+.comments {
+  margin-left: 1.5rem;
+}
+
+.comments li {
+  border: none;
+  padding: 0.25rem 0;
+}
+
+.comment-form {
+  display: flex;
+  gap: 0.5rem;
+  margin-left: 1.5rem;
+}
+
+.comment-form input {
+  flex: 1;
+}
+
+@media (min-width: 600px) {
+  #case-form,
+  #task-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  #case-form input,
+  #task-form input {
+    flex: 1;
+  }
+
+  #task-form select {
+    flex: 0 0 40%;
+    margin-top: 0;
+  }
+
+  #case-form button,
+  #task-form button {
+    flex: 0 0 auto;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add mobile viewport and Google Fonts, reorganizing layout into card-based sections
- implement modern CSS with variables, responsive forms, and sleek styling
- refine task screen with color-coded statuses and collapsible comment sections for intuitive use

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9cca84883249983d4f47a1ebf14