### PR TITLE
Revamp UI with modern mobile-first design

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,47 +2,53 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Case Tasks & Notes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div id="case-list-section">
-    <h1>Cases</h1>
-    <ul id="case-list"></ul>
-    <form id="case-form">
-      <input id="case-input" placeholder="New case title">
-      <button type="submit">Add Case</button>
-    </form>
-  </div>
-
-  <div id="case-detail" hidden>
-    <button id="back-btn">Back</button>
-    <h2 id="case-title"></h2>
-
-    <section id="tasks">
-      <h3>Tasks</h3>
-      <form id="task-form">
-        <input id="task-input" placeholder="Task description">
-        <select id="task-status">
-          <option value="open">Open</option>
-          <option value="in progress">In Progress</option>
-          <option value="complete">Complete</option>
-        </select>
-        <button type="submit">Add Task</button>
+  <main class="app">
+    <section id="case-list-section" class="card">
+      <h1>Cases</h1>
+      <ul id="case-list"></ul>
+      <form id="case-form" class="stack">
+        <input id="case-input" placeholder="New case title">
+        <button type="submit" class="primary">Add Case</button>
       </form>
-      <ul id="task-list"></ul>
     </section>
 
-    <section id="notes">
-      <h3>Notes</h3>
-      <form id="note-form">
-        <textarea id="note-input" placeholder="Add note..."></textarea>
-        <button type="submit">Add Note</button>
-      </form>
-      <ul id="notes-list"></ul>
-    </section>
-  </div>
+    <section id="case-detail" class="card" hidden>
+      <button id="back-btn" class="back-btn">&larr; Back</button>
+      <h2 id="case-title"></h2>
 
+      <section id="tasks">
+        <h3>Tasks</h3>
+        <form id="task-form" class="stack">
+          <input id="task-input" placeholder="Task description">
+          <select id="task-status" class="status-select" data-status="open">
+            <option value="open">Open</option>
+            <option value="in progress">In Progress</option>
+            <option value="complete">Complete</option>
+          </select>
+          <button type="submit" class="primary">Add Task</button>
+        </form>
+        <ul id="task-list"></ul>
+      </section>
+
+      <section id="notes">
+        <h3>Notes</h3>
+        <form id="note-form" class="stack">
+          <textarea id="note-input" placeholder="Add note..."></textarea>
+          <button type="submit" class="primary">Add Note</button>
+        </form>
+        <ul id="notes-list"></ul>
+      </section>
+    </section>
+  </main>
   <script type="module" src="script.js"></script>
 </body>
 </html>
+

--- a/script.js
+++ b/script.js
@@ -117,41 +117,69 @@ function startRealtimeTasks(caseId) {
         const text = await decryptText(data.textCipher, data.textIv);
         const status = await decryptText(data.statusCipher, data.statusIv);
         const li = document.createElement('li');
-        const span = document.createElement('span');
-        span.textContent = text;
-        li.appendChild(span);
+        li.className = 'task-item';
+        li.dataset.status = status;
+
+        const titleSpan = document.createElement('span');
+        titleSpan.className = 'task-title';
+        titleSpan.textContent = text;
+        li.appendChild(titleSpan);
+
+        const actions = document.createElement('div');
+        actions.className = 'task-actions';
+        li.appendChild(actions);
 
         const select = document.createElement('select');
+        select.className = 'status-select';
         ['open','in progress','complete'].forEach(s => {
           const opt = document.createElement('option');
           opt.value = s; opt.textContent = s; select.appendChild(opt);
         });
         select.value = status;
+        select.dataset.status = status;
         select.addEventListener('change', async () => {
           const { cipher, iv } = await encryptText(select.value);
           await updateDoc(doc(db, 'cases', caseId, 'tasks', docSnap.id), { statusCipher: cipher, statusIv: iv });
+          select.dataset.status = select.value;
+          li.dataset.status = select.value;
         });
-        li.appendChild(select);
+        actions.appendChild(select);
 
         const del = document.createElement('button');
-        del.textContent = 'Delete';
+        del.className = 'icon-btn delete-btn';
+        del.textContent = '🗑';
+        del.setAttribute('aria-label', 'Delete task');
         del.addEventListener('click', async () => {
           await deleteDoc(doc(db, 'cases', caseId, 'tasks', docSnap.id));
         });
-        li.appendChild(del);
+        actions.appendChild(del);
+
+        const toggle = document.createElement('button');
+        toggle.type = 'button';
+        toggle.className = 'icon-btn comment-toggle';
+        toggle.textContent = '💬';
+        toggle.setAttribute('aria-label', 'Show comments');
+        actions.appendChild(toggle);
 
         // comments section
+        const commentSection = document.createElement('div');
+        commentSection.className = 'comment-section';
+        commentSection.hidden = true;
+
         const commentsList = document.createElement('ul');
         commentsList.className = 'comments';
-        li.appendChild(commentsList);
-        startRealtimeComments(caseId, docSnap.id, commentsList);
+        commentSection.appendChild(commentsList);
 
         const commentForm = document.createElement('form');
+        commentForm.className = 'comment-form';
         const commentInput = document.createElement('input');
         commentInput.placeholder = 'Add comment';
         commentForm.appendChild(commentInput);
         const commentBtn = document.createElement('button');
-        commentBtn.textContent = 'Add';
+        commentBtn.className = 'icon-btn add-comment-btn';
+        commentBtn.type = 'submit';
+        commentBtn.textContent = '➕';
+        commentBtn.setAttribute('aria-label', 'Add comment');
         commentForm.appendChild(commentBtn);
         commentForm.addEventListener('submit', async e => {
           e.preventDefault();
@@ -163,7 +191,20 @@ function startRealtimeTasks(caseId) {
           });
           commentInput.value = '';
         });
-        li.appendChild(commentForm);
+        commentSection.appendChild(commentForm);
+        li.appendChild(commentSection);
+
+        let commentsLoaded = false;
+        toggle.addEventListener('click', () => {
+          const hidden = commentSection.hidden;
+          commentSection.hidden = !hidden;
+          toggle.textContent = hidden ? '✖' : '💬';
+          toggle.setAttribute('aria-label', hidden ? 'Hide comments' : 'Show comments');
+          if (hidden && !commentsLoaded) {
+            startRealtimeComments(caseId, docSnap.id, commentsList);
+            commentsLoaded = true;
+          }
+        });
 
         taskListEl.appendChild(li);
       } catch (err) {
@@ -174,11 +215,13 @@ function startRealtimeTasks(caseId) {
 }
 
 function startRealtimeComments(caseId, taskId, listEl) {
-  const q = query(collection(db, 'cases', caseId, 'tasks', taskId, 'comments'), orderBy('createdAt', 'desc'));
+  const q = collection(db, 'cases', caseId, 'tasks', taskId, 'comments');
   onSnapshot(q, async snap => {
+    const docs = snap.docs
+      .map(s => ({ id: s.id, ...s.data() }))
+      .sort((a, b) => (b.createdAt?.toMillis?.() ?? 0) - (a.createdAt?.toMillis?.() ?? 0));
     listEl.innerHTML = '';
-    for (const docSnap of snap.docs) {
-      const { cipher, iv, username: user } = docSnap.data();
+    for (const { cipher, iv, username: user } of docs) {
       try {
         const text = await decryptText(cipher, iv);
         const li = document.createElement('li');
@@ -188,7 +231,7 @@ function startRealtimeComments(caseId, taskId, listEl) {
         console.error('Skipping undecryptable comment', err);
       }
     }
-  });
+  }, err => console.error('Comments listener error', err));
 }
 
 function startRealtimeNotes(caseId) {
@@ -234,6 +277,10 @@ function bindCaseForm() {
 }
 
 function bindTaskForm() {
+  taskStatus.addEventListener('change', () => {
+    taskStatus.dataset.status = taskStatus.value;
+  });
+
   taskForm.addEventListener('submit', async e => {
     e.preventDefault();
     if (!currentCaseId) return;
@@ -247,6 +294,7 @@ function bindTaskForm() {
     });
     taskInput.value = '';
     taskStatus.value = 'open';
+    taskStatus.dataset.status = 'open';
   });
 }
 

--- a/style.css
+++ b/style.css
@@ -1,8 +1,267 @@
-body { font-family: sans-serif; margin: 2rem; }
-form { margin: 1rem 0; }
-textarea { width: 100%; height: 4rem; }
-#case-list li { cursor: pointer; margin-bottom: .5rem; }
-#task-list li { margin-bottom: .5rem; }
-#task-list select { margin-left: .5rem; }
-#task-list button { margin-left: .5rem; }
-.comments { margin-left: 1.5rem; font-size: 0.9em; }
+:root {
+  --bg: #f5f7fa;
+  --bg2: #e0e7ff;
+  --card-bg: #ffffff;
+  --primary: #2563eb;
+  --primary-hover: #1e40af;
+  --text: #1f2937;
+  --muted: #6b7280;
+  --radius: 0.5rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  background: linear-gradient(var(--bg), var(--bg2));
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.app {
+  padding: 1rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1,
+h2,
+h3 {
+  font-weight: 600;
+  margin: 0 0 1rem;
+  color: var(--primary);
+}
+
+ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  padding: 1rem;
+  margin-bottom: 1.5rem;
+  border-top: 4px solid var(--primary);
+}
+
+.stack > * + * {
+  margin-top: 0.75rem;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #d1d5db;
+  border-radius: var(--radius);
+  background: #fff;
+}
+
+textarea {
+  min-height: 4rem;
+  resize: vertical;
+}
+
+button {
+  padding: 0.75rem 1rem;
+  border: none;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+}
+
+button.primary:hover {
+  background: var(--primary-hover);
+}
+
+.back-btn {
+  background: none;
+  color: var(--muted);
+  padding: 0;
+  margin-bottom: 1rem;
+}
+
+#case-list li,
+#task-list li,
+#notes-list li {
+  padding: 0.75rem;
+  border: 1px solid #e5e7eb;
+  border-radius: var(--radius);
+  margin-bottom: 0.5rem;
+  background: #fff;
+}
+
+#case-list li {
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+#case-list li:hover {
+  background: #f3f4f6;
+}
+
+#task-form,
+#note-form {
+  margin-top: 1rem;
+}
+
+#task-form select {
+  margin-top: 0.75rem;
+}
+
+#notes-list li button {
+  margin-left: 0.5rem;
+  background: none;
+  color: var(--primary);
+}
+
+#task-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.task-title {
+  font-weight: 500;
+}
+
+.task-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.task-actions select {
+  flex: 1;
+}
+
+.icon-btn {
+  background: none;
+  border: none;
+  color: var(--primary);
+  padding: 0.25rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+.icon-btn:hover {
+  background: #e0e7ff;
+}
+
+.delete-btn {
+  color: #ef4444;
+}
+
+.add-comment-btn {
+  color: #10b981;
+}
+
+.status-select {
+  border: none;
+  border-radius: var(--radius);
+  padding: 0.25rem 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.status-select[data-status="open"] {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.status-select[data-status="in progress"] {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.status-select[data-status="complete"] {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.task-item[data-status="complete"] span {
+  text-decoration: line-through;
+  color: var(--muted);
+}
+
+.task-item[data-status="open"] {
+  border-left: 4px solid #f87171;
+  background: #fee2e2;
+}
+
+.task-item[data-status="in progress"] {
+  border-left: 4px solid #fbbf24;
+  background: #fef3c7;
+}
+
+.task-item[data-status="complete"] {
+  border-left: 4px solid #34d399;
+  background: #dcfce7;
+}
+
+.comment-section {
+  margin-left: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.comments li {
+  border: none;
+  padding: 0.25rem 0;
+}
+
+.comment-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.comment-form input {
+  flex: 1;
+}
+
+@media (min-width: 600px) {
+  #case-form,
+  #task-form {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+  }
+
+  #case-form input,
+  #task-form input {
+    flex: 1;
+  }
+
+  #task-form select {
+    flex: 0 0 40%;
+    margin-top: 0;
+  }
+
+  #case-form button,
+  #task-form button {
+    flex: 0 0 auto;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add mobile viewport and Google Fonts, reorganizing layout into card-based sections
- implement modern CSS with variables, responsive forms, and sleek styling
- refine task screen with color-coded statuses and collapsible comment sections for intuitive use
- split task titles into their own lines and replace task action buttons with intuitive icons
- infuse design with gradient background, primary-colored headings, and status-tinted task cards for more color
- ensure task comments render by wrapping the list and form in a toggleable section
- load comments on demand when toggling a task's discussion and style the section for clearer display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb9cca84883249983d4f47a1ebf14